### PR TITLE
Add read time

### DIFF
--- a/og-generator.php
+++ b/og-generator.php
@@ -25,7 +25,7 @@ foreach ($posts as $post) {
     $contents = file_get_contents($post);
     $frontMatter = YamlFrontMatter::parse($contents);
 
-    $read_time = 11; // TODO: Calculate read time
+    $read_time = ceil(str_word_count($contents) / 200);
     $filename = basename($post, '.md');
     $url = 'https://your-blog.com/'.$filename;
     $filename .= '-og.png';


### PR DESCRIPTION
This adds reading time calculation by dividing the number of words in the article by 200.

[Related search](https://www.google.com/search?q=how+to+calculate+reading+time)

I'm doing `ceil` to avoid having `0` minutes reading time. You can change it to this to avoid `0` minute reading time and have more accurate estimates for higher numbers:
```php
max(1, round(str_word_count($contents) / 200))
```
or even use `floor` if you want to give generally smaller estimates and encourage reading.
In that spirit you could also divide by 238 which is the more accurate average according to research, or even go higher.